### PR TITLE
Upgrade PivotTable.js and enable TSV export

### DIFF
--- a/rd_ui/app/index.html
+++ b/rd_ui/app/index.html
@@ -146,6 +146,7 @@
 <script src="/bower_components/gridster/dist/jquery.gridster.js"></script>
 <script src="/bower_components/angular-growl/build/angular-growl.js"></script>
 <script src="/bower_components/pivottable/dist/pivot.js"></script>
+<script src="/bower_components/pivottable/dist/export_renderers.js"></script>
 <script src="/bower_components/cornelius/src/cornelius.js"></script>
 <script src="/bower_components/mousetrap/mousetrap.js"></script>
 <script src="/bower_components/mousetrap/plugins/global-bind/mousetrap-global-bind.js"></script>

--- a/rd_ui/app/scripts/visualizations/pivot.js
+++ b/rd_ui/app/scripts/visualizations/pivot.js
@@ -19,8 +19,10 @@ renderers.directive('pivotTableRenderer', function () {
                     // We need to give the pivot table its own copy of the data, because its change
                     // it which interferes with other visualizations.
                     var data = $.extend(true, [], $scope.queryResult.getData());
+                    var renderers = $.extend($.pivotUtilities.renderers,
+                      $.pivotUtilities.export_renderers)
                     $(element).pivotUI(data, {
-                         renderers: $.pivotUtilities.renderers
+                         renderers: renderers
                     }, true);
                 }
             });

--- a/rd_ui/bower.json
+++ b/rd_ui/bower.json
@@ -15,7 +15,7 @@
     "codemirror": "4.8.0",
     "highcharts": "3.0.10",
     "underscore": "1.5.1",
-    "pivottable": "~1.1.1",
+    "pivottable": "1.6.3",
     "cornelius": "https://github.com/restorando/cornelius.git",
     "gridster": "0.2.0",
     "mousetrap": "~1.4.6",


### PR DESCRIPTION
This should close hudl/fulla#139.

I simply upgraded the PivotTable.js library and included the `export_renderers.js` file and passed the new renderers into `pivotUI()`.

![pivottable](https://cloud.githubusercontent.com/assets/4348863/10321368/e45b07d2-6c3d-11e5-9000-921e3c5b9dbc.gif)

