### PR TITLE
Default data source

### DIFF
--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -63,7 +63,7 @@
     <hr>
     <div class="row" ng-if="sourceMode">
         <div class="col-md-3 schema-container hidden-sm hidden-xs" ng-if="hasSchema">
-            <div ng-show="schema.length < 500">
+            <div ng-show="schema.length < 5000">
                 <input type="text" placeholder="Search schema..." class="form-control" ng-model="schemaFilter">
             </div>
             <div class="schema-browser">

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -2,6 +2,8 @@ from flask import make_response, request
 from flask_restful import abort
 from funcy import project
 
+from operator import itemgetter
+
 from redash import models
 from redash.utils.configuration import ConfigurationContainer, ValidationError
 from redash.permissions import require_admin, require_permission, require_access, view_only
@@ -68,7 +70,10 @@ class DataSourceListResource(BaseResource):
             d['view_only'] = all(project(ds.groups, self.current_user.groups).values())
             response[ds.id] = d
 
-        return response.values()
+        # Sorting by ID before returning makes it easier to set default source on front end -- ABD
+        sources = sorted(response.values(), key=itemgetter('id'))
+
+        return sources
 
     @require_admin
     def post(self):


### PR DESCRIPTION
This PR makes two small fixes:

1. In the DataSourceList API call, it explicitly sorts the data sources by ID before returning. This makes it easier to set the default data source by selecting the first one in the list.

2. Increase the table limit for the Schema search bar.