### PR TITLE
Remove "re:dash |" from page title

### DIFF
--- a/rd_ui/app/app_layout.html
+++ b/rd_ui/app/app_layout.html
@@ -5,7 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" ng-app="redash" ng-controller='MainCtrl'> <!--<![endif]-->
 <head>
     <base href="{{base_href}}">
-    <title ng-bind="'{{name}} | ' + pageTitle"></title>
+    <title ng-bind="pageTitle"></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 


### PR DESCRIPTION
Now the title just shows the name of the query or dashboard so it's easier to find which query you want with multiple open tabs.